### PR TITLE
Make activerecord requirement allow all 7.1.0.alpha versions

### DIFF
--- a/activerecord-trilogy-adapter.gemspec
+++ b/activerecord-trilogy-adapter.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency "trilogy", ">= 2.1.1"
-  spec.add_dependency "activerecord", ">= 7.1.0.alpha"
+  spec.add_dependency "activerecord", "~> 7.1.a"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-focus", "~> 1.1"
   spec.add_development_dependency "pry", "~> 0.10"


### PR DESCRIPTION
This fixes incorrect version requirements from when using commit versions,

    Gem::Version.new('7.1.0.alpha.d6973d50d0') < Gem::Version.new('7.1.0.alpha')

is true.