### PR TITLE
Require a valid connection when quoting a string

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -116,7 +116,9 @@ module ActiveRecord
       end
 
       def quote_string(string)
-        any_raw_connection.escape string
+        with_raw_connection(allow_retry: true, uses_transaction: false) do |conn|
+          conn.escape(string)
+        end
       end
 
       def active?
@@ -199,7 +201,9 @@ module ActiveRecord
         end
 
         def get_full_version
-          any_raw_connection.server_info[:version]
+          with_raw_connection(allow_retry: true, uses_transaction: false) do |conn|
+            conn.server_info[:version]
+          end
         end
 
         def translate_exception(exception, message:, sql:, binds:)

--- a/lib/trilogy_adapter/lost_connection_exception_translator.rb
+++ b/lib/trilogy_adapter/lost_connection_exception_translator.rb
@@ -35,7 +35,7 @@ module TrilogyAdapter
         case exception
         when Errno::EPIPE
           Errors::BrokenPipe.new(message)
-        when SocketError
+        when SocketError, IOError
           Errors::SocketError.new(message)
         when Errno::ECONNRESET
           Errors::ConnectionResetByPeer.new(message)

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -96,6 +96,14 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert_equal "\\\"test\\\"", @adapter.quote_string(%("test"))
   end
 
+  test "#quote_string works when the connection is known to be closed" do
+    adapter = trilogy_adapter
+    adapter.connect!
+    adapter.instance_variable_get(:@raw_connection).close
+
+    assert_equal "\\\"test\\\"", adapter.quote_string(%("test"))
+  end
+
   test "#quoted_true answers TRUE" do
     assert_equal "TRUE", @adapter.quoted_true
   end


### PR DESCRIPTION
The underlying Trilogy driver will raise an IOError inside #escape if the socket is closed, so we need to ensure we have a valid connection, and allow retries if necessary, when quoting a string.

IOError was also not previously on the list of known connectivity- related errors, so fix that too, by treating it the same as SocketError.

