### PR TITLE
Parse ssl-mode when creating the client

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -79,9 +79,17 @@ module ActiveRecord
       }.freeze
 
       class << self
+        def database_driver=(database_driver = ::Trilogy)
+          @database_driver = database_driver
+        end
+
+        def database_driver
+          @database_driver ||= ::Trilogy
+        end
+
         def new_client(config)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
-          ::Trilogy.new(config)
+          database_driver.new(config)
         rescue Trilogy::DatabaseError => error
           raise translate_connect_error(config, error)
         end

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -79,17 +79,9 @@ module ActiveRecord
       }.freeze
 
       class << self
-        def database_driver=(database_driver = ::Trilogy)
-          @database_driver = database_driver
-        end
-
-        def database_driver
-          @database_driver ||= ::Trilogy
-        end
-
         def new_client(config)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
-          database_driver.new(config)
+          ::Trilogy.new(config)
         rescue Trilogy::DatabaseError => error
           raise translate_connect_error(config, error)
         end

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -87,9 +87,6 @@ module ActiveRecord
         end
 
         def parse_ssl_mode(mode)
-          return unless mode
-
-          # return mode if it's already a Trilogy::SSL_MODE
           return mode if mode.is_a? Integer
 
           m = mode.to_s.upcase

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -70,11 +70,33 @@ module ActiveRecord
 
       include DatabaseStatements
 
+      SSL_MODES = {
+        SSL_MODE_DISABLED: Trilogy::SSL_DISABLED,
+        SSL_MODE_PREFERRED: Trilogy::SSL_PREFERRED_NOVERIFY,
+        SSL_MODE_REQUIRED: Trilogy::SSL_REQUIRED_NOVERIFY,
+        SSL_MODE_VERIFY_CA: Trilogy::SSL_VERIFY_CA,
+        SSL_MODE_VERIFY_IDENTITY: Trilogy::SSL_VERIFY_IDENTITY
+      }.freeze
+
       class << self
         def new_client(config)
+          config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
           ::Trilogy.new(config)
         rescue Trilogy::DatabaseError => error
           raise translate_connect_error(config, error)
+        end
+
+        def parse_ssl_mode(mode)
+          return unless mode
+
+          # return mode if it's already a Trilogy::SSL_MODE
+          return mode if mode.is_a? Integer
+
+          m = mode.to_s.upcase
+          # enable Mysql2 client compatibility
+          m = "SSL_MODE_#{m}" unless m.start_with? "SSL_MODE_"
+
+          SSL_MODES.fetch(m.to_sym, mode)
         end
 
         def translate_connect_error(config, error)

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -849,6 +849,27 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     ActiveRecord.query_transformers = old_query_transformers if ActiveRecord.respond_to?(:query_transformers)
   end
 
+  test "parses ssl_mode as int" do
+    adapter = trilogy_adapter(ssl_mode: 0)
+    adapter.connect!
+
+    assert adapter.active?
+  end
+
+  test "parses ssl_mode as string" do
+    adapter = trilogy_adapter(ssl_mode: "disabled")
+    adapter.connect!
+
+    assert adapter.active?
+  end
+
+  test "parses ssl_mode as string prefixed" do
+    adapter = trilogy_adapter(ssl_mode: "SSL_MODE_DISABLED")
+    adapter.connect!
+
+    assert adapter.active?
+  end
+
   def trilogy_adapter_with_connection(connection, **config_overrides)
     ActiveRecord::ConnectionAdapters::TrilogyAdapter
       .new(connection, nil, {}, @configuration.merge(config_overrides))


### PR DESCRIPTION
Parses `ssl-mode` from database config so it can support the strings expected by mysql as well as the current integer values that Trilogy expects.
