### PR TITLE
Set default_prepared_statements for trilogy

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -212,6 +212,10 @@ module ActiveRecord
           ::TrilogyAdapter::LostConnectionExceptionTranslator.
             new(exception, message, error_code).translate || super
         end
+
+        def default_prepared_statements
+          false
+        end
     end
   end
 end

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -32,6 +32,10 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert_match %(possible_keys), explain
   end
 
+  test "#default_prepared_statements" do
+    assert_not_predicate @pool.connection, :prepared_statements?
+  end
+
   test "#adapter_name answers name" do
     assert_equal "Trilogy", @adapter.adapter_name
   end


### PR DESCRIPTION
Trilogy doesn't support prepared statements yet so until https://github.com/github/trilogy/pull/3 is merged and support is implemented in the adapter this should be set to false.

Fixes #5