### PR TITLE
Call `super` in `TrilogyAdapter#disconnect!`

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -149,6 +149,7 @@ module ActiveRecord
       alias reset! reconnect!
 
       def disconnect!
+        super
         unless connection.nil?
           connection.close
           self.connection = nil


### PR DESCRIPTION
This way, we clear caching, reset transactions, and set `@raw_connection_dirty` to nil whenever `#disconnect!` is called.
All of the other adapters in Rails call `super`, so I'm assuming this was an oversight, but please correct me if there's a reason we're not doing this currently.

Let me know if you'd prefer explicit tests for this, or if we're happy to rely on the upstream tests for this.