### PR TITLE
Rely on `AbstractMysqlAdapter#execute`

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -30,13 +30,6 @@ module ActiveRecord
           MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
         end
 
-        def execute(sql, name = nil, async: false)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-
-          raw_execute(sql, name, async: async)
-        end
-
         def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
           result = execute(sql, name, async: async)
           ActiveRecord::Result.new(result.fields, result.to_a)


### PR DESCRIPTION
We should rely on `AbstractMysqlAdapter`'s `#execute` method so that we pull in the `allow_retry` option.

When set to `true`, the SQL statement will be retried, up to the database's configured `connection_retries` value, upon encountering connection-related errors.

This option is supported on `AbstractAdapter` and the other adapters upstream, as of https://github.com/rails/rails/pull/46273.