### PR TITLE
Don't pin to specific commits for actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       DB_HOST: 127.0.0.1
       DB_PORT: 3306
     steps:
-    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+    - uses: actions/checkout@v3
     - name: Cache .gem files
       uses: actions/cache@v3
       with:
@@ -26,7 +26,7 @@ jobs:
         path: vendor/cache
     - name: Start mysql
       run: docker run -d --rm --name=mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -p 3306:3306 --health-interval=1s --health-timeout=5s --health-retries=5  --volume="$(pwd)"/script/setup.sql:/docker-entrypoint-initdb.d/setup.sql  --health-cmd='mysql trilogy_test -e "select * from posts"'  mysql:5.7 --sql_mode=NO_ENGINE_SUBSTITUTION --log-bin --server-id=1 --gtid-mode=ON --enforce-gtid-consistency=ON
-    - uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
         bundler-cache: true


### PR DESCRIPTION
I'd like to reduce the dependabot noise a bit. These are both well-trusted actions, and I think it should be fine to have more relaxed versioning. Plus we're already using this approach in rubocop-github and trilogy.