### PR TITLE
AR 7.1 update affected test for AbstractAdapter#transform_query

### DIFF
--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -890,7 +890,7 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
 
     # Add custom query transformer
     old_query_transformers = ActiveRecord.query_transformers
-    ActiveRecord.query_transformers = [-> (sql) { sql + " /* it works */" }]
+    ActiveRecord.query_transformers = [-> (sql, _adapter) { sql + " /* it works */" }]
 
     sql = "SELECT * FROM posts;"
 


### PR DESCRIPTION
A recently-merged update to ActiveRecord now causes the adapter context to be brought in when query transformers are being called.  Here is the relevant method in **AbstractAdapter**, note the addition of the parameter `self`:
```
def transform_query(sql)
  ActiveRecord.query_transformers.each do |transformer|
    sql = transformer.call(sql, self)
  end
  sql
end
```

It's part of this commit:
https://github.com/rails/rails/commit/d3b41750fb308662a9871139e6cd39849b0c03d8