### PR TITLE
Avoid "comparison of Gem::Version..." error in Ruby < 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         rails_version:
         - main
         ruby_version:
-        - '3.0'
+        - '3.1'
       fail-fast: false
     runs-on: ubuntu-latest
     name: Test on Rails ${{ matrix.rails_version }}


### PR DESCRIPTION
When using Ruby < 3.1 with edge Rails this error appears:
```
/activerecord/lib/active_record/coders/yaml_column.rb:14:in `>=': comparison of Gem::Version with String failed (ArgumentError)
```
This updates `ci.yml` to use Ruby 3.1.x.

If edge Rails is updated with [Rails #47480](https://github.com/rails/rails/pull/47480) then this PR does not need to be merged into ARTA.