### PR TITLE
Bump minimum Trilogy version to 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,4 @@ else
   gem "activerecord", ENV["RAILS_VERSION"]
 end
 
-gem "trilogy", git: "https://github.com/github/trilogy", branch: "main", glob: "contrib/ruby/*.gemspec"
-
 gemspec

--- a/activerecord-trilogy-adapter.gemspec
+++ b/activerecord-trilogy-adapter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     "bug_tracker_uri" => "https://github.com/github/activerecord-trilogy-adapter/issues"
   }
 
-  spec.add_dependency "trilogy", ">= 2.1.1"
+  spec.add_dependency "trilogy", ">= 2.3.0"
   spec.add_dependency "activerecord", "~> 7.1.a"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-focus", "~> 1.1"


### PR DESCRIPTION
We're already using some of the new error constants from that release (see https://github.com/github/activerecord-trilogy-adapter/pull/24) so we need to bump.