### PR TITLE
Update to reference Trilogy::BaseError in a failure message

### DIFF
--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -187,7 +187,7 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     rescue ActiveRecord::StatementInvalid => ex
       assert_instance_of Trilogy::BaseError, ex.cause
     else
-      flunk "Expected Trilogy::Error to be raised"
+      flunk "Expected Trilogy::BaseError to be raised"
     end
 
     assert_nil adapter.send(:connection)


### PR DESCRIPTION
Had noticed with #32 -- this occurrence of `Trilogy::Error` might need to be updated.