### PR TITLE
Implement #high_precision_current_timestamp

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -15,6 +15,9 @@ module ActiveRecord
         ) # :nodoc:
         private_constant :READ_QUERY
 
+        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
+        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
         rescue ArgumentError # Invalid encoding
@@ -47,6 +50,10 @@ module ActiveRecord
         end
 
         alias :exec_update :exec_delete
+
+        def high_precision_current_timestamp
+          HIGH_PRECISION_CURRENT_TIMESTAMP
+        end
 
         private
           def last_inserted_id(result)


### PR DESCRIPTION
See https://github.com/rails/rails/pull/42993.

This will ensure that full SQL precision is used when updating timestamps via `#insert_all` / `#update_all`.