### PR TITLE
Implement `with_multi_statements` to unblock concurrent fixture insertion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,6 @@ else
   gem "activerecord", ENV["RAILS_VERSION"]
 end
 
+gem "trilogy", git: "https://github.com/github/trilogy", branch: "main", glob: "contrib/ruby/*.gemspec"
+
 gemspec

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -209,6 +209,61 @@ module ActiveRecord
           end
         end
 
+        def execute_batch(statements, name = nil)
+          statements = statements.map { |sql| transform_query(sql) }
+          combine_multi_statements(statements).each do |statement|
+            with_raw_connection do |conn|
+              raw_execute(statement, name)
+              conn.next_result while conn.more_results_exist?
+            end
+          end
+        end
+
+        def multi_statements_enabled?
+          !!@config[:multi_statement]
+        end
+
+        def with_multi_statements
+          if multi_statements_enabled?
+            return yield
+          end
+
+          with_raw_connection do |conn|
+            conn.set_server_option(Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
+
+            yield
+          ensure
+            conn.set_server_option(Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF)
+          end
+        end
+
+        def combine_multi_statements(total_sql)
+          total_sql.each_with_object([]) do |sql, total_sql_chunks|
+            previous_packet = total_sql_chunks.last
+            if max_allowed_packet_reached?(sql, previous_packet)
+              total_sql_chunks << +sql
+            else
+              previous_packet << ";\n"
+              previous_packet << sql
+            end
+          end
+        end
+
+        def max_allowed_packet_reached?(current_packet, previous_packet)
+          if current_packet.bytesize > max_allowed_packet
+            raise ActiveRecordError,
+              "Fixtures set is too large #{current_packet.bytesize}. Consider increasing the max_allowed_packet variable."
+          elsif previous_packet.nil?
+            true
+          else
+            (current_packet.bytesize + previous_packet.bytesize + 2) > max_allowed_packet
+          end
+        end
+
+        def max_allowed_packet
+          @max_allowed_packet ||= show_variable("max_allowed_packet")
+        end
+
         def full_version
           schema_cache.database_version.full_version_string
         end

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -360,6 +360,64 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     end
   end
 
+  class Post < ActiveRecord::Base; end
+
+  test "bulk fixture inserts when multi statement is configured" do
+    ActiveRecord::Base.establish_connection(@configuration.merge(multi_statement: true))
+    conn = ActiveRecord::Base.connection
+
+    fixtures = {
+      "posts" => [
+        { "id" => 1, "title" => "Foo", "body" => "Something", "kind" => "something else", "created_at" => Time.now.utc, "updated_at" => Time.now.utc },
+        { "id" => 2, "title" => "Bar", "body" => "Something Else", "kind" => "something", "created_at" => Time.now.utc, "updated_at" => Time.now.utc },
+      ]
+    }
+
+    assert_nothing_raised do
+      conn.execute("SELECT 1; SELECT 2;")
+      conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
+    end
+
+    assert_difference "Post.count", 2 do
+      conn.insert_fixtures_set(fixtures)
+    end
+
+    assert_nothing_raised do
+      conn.execute("SELECT 1; SELECT 2;")
+      conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
+    end
+  ensure
+    Post.delete_all
+  end
+
+  test "bulk fixture inserts when multi_statement is disabled by default" do
+    ActiveRecord::Base.establish_connection(@configuration.merge(multi_statement: false))
+    conn = ActiveRecord::Base.connection
+
+    fixtures = {
+      "posts" => [
+        { "id" => 1, "title" => "Foo", "body" => "Something", "kind" => "something else", "created_at" => Time.now.utc, "updated_at" => Time.now.utc },
+        { "id" => 2, "title" => "Bar", "body" => "Something Else", "kind" => "something", "created_at" => Time.now.utc, "updated_at" => Time.now.utc },
+      ]
+    }
+
+    assert_raises(ActiveRecord::StatementInvalid) do
+      conn.execute("SELECT 1; SELECT 2;")
+      conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
+    end
+
+    assert_difference "Post.count", 2 do
+      conn.insert_fixtures_set(fixtures)
+    end
+
+    assert_raises(ActiveRecord::StatementInvalid) do
+      conn.execute("SELECT 1; SELECT 2;")
+      conn.raw_connection.next_result while conn.raw_connection.more_results_exist?
+    end
+  ensure
+    Post.delete_all
+  end
+
   test "query flags for timezone can be set to local and reset to utc" do
     if ActiveRecord.respond_to?(:default_timezone)
       old_timezone, ActiveRecord.default_timezone = ActiveRecord.default_timezone, :local


### PR DESCRIPTION
Depends on https://github.com/github/trilogy/pull/52
Closes #37

This PR defines methods `execute_batch` and `with_multi_statements` to leverage multi statement insertion during the `insert_fixture_set` flow. It's mostly inspired by the implementation of `Mysql2Adapter` upstream, and much of this code can be de-duplicated when Trilogy makes its way upstream.

I've added 2 test cases for the cases when `multi_statement` is enabled/disabled to start.

Once we merge the Trilogy changes, I'll update this PR to use main/the new release.